### PR TITLE
Fixed podfile

### DIFF
--- a/RNFileShareIntent.podspec
+++ b/RNFileShareIntent.podspec
@@ -4,9 +4,9 @@ Pod::Spec.new do |s|
   s.version      = "1.0.0"
   s.summary      = "RNFileShareIntent"
   s.description  = <<-DESC
-                  RNFileShareIntent
+                  Adds the application to the share intent of the device, so it can be launched from other apps and receive data from them
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/andriystabryn/react-native-file-share-intent"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
The podfile currently shows this error when installing with React Native 0.60:

```
[!] The `RNFileShareIntent` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```

So I've set the homepage attribute to remove the error, and also set the description. Fixing the source attribute would be more complicated so I've left it as it is.