### PR TITLE
Fixed import statement for RCTLog

### DIFF
--- a/ios/src/RNFileShareIntent.m
+++ b/ios/src/RNFileShareIntent.m
@@ -11,7 +11,7 @@
 #import "OperationRetrieval.h"
 
 #import <MobileCoreServices/MobileCoreServices.h>
-#import <RCTLog.h>
+#import "RCTLog.h"
 #import "FileHelper.h"
 
 


### PR DESCRIPTION
With RN 0.60+, it needs to be with quotes

Maybe we need a new tag too as it might be a breaking change.